### PR TITLE
Containerize cerberus

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ daemon_mode: True
 $ python3 src/cerberus.py --config <config_file_location>
 ```
 
+#### Run containerized version
+Assuming that the latest docker ( 17.05 or greater with multi-build support ) is intalled on the host, run:
+```
+$ cd containers
+$ docker build -t cerberus:latest .
+$ docker run --name=cerberus -v <path_to_kubeconfig>:/root/.kube/config -v <path_to_cerberus_config>:/root/cerberus/config/config.ini -d cerberus:latest
+$ docker logs -f cerberus
+```
+
+Similarly, podman can be used to achieve the same:
+```
+$ cd containers
+$ podman build -t cerberus:latest .
+$ podman run --name=cerberus -v <path_to_kubeconfig>:/root/.kube/config:Z -v <path_to_cerberus_config>:/root/cerberus/config/config.ini:Z -d cerberus:latest
+$ podman logs -f cerberus
+```
+
+NOTE: The report is generated at /root/cerberus/cerberus.report inside the container, it can mounted to a directory on the host in case we want to capture it.
+
 #### Report
 The report is generated in the run directory and it contains the information about each check/monitored component status per iteration with timestamps. It also displays information about the components in case of failure. For example:
 ```

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile for cerberus
+
+FROM quay.io/openshift/origin-tests:latest as origintests
+
+FROM centos:7
+
+MAINTAINER Red Hat OpenShift Performance and Scale
+
+ENV KUBECONFIG /root/.kube/config
+
+# Copy OpenShift CLI, Kubernetes CLI from origin-tests image
+COPY --from=origintests /usr/bin/oc /usr/bin/oc
+COPY --from=origintests /usr/bin/kubectl /usr/bin/kubectl
+
+# Install dependencies
+RUN yum install -y git python36 python3-pip && \
+git clone https://github.com/openshift-scale/cerberus /root/cerberus && \
+mkdir -p /root/.kube && cd /root/cerberus && \
+pip3 install -r requirements.txt
+
+WORKDIR /root/cerberus
+
+ENTRYPOINT python3 src/cerberus.py --config=config/config.ini

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,5 @@
+### Cerberus image
+TODO: Container image gets automatically built by quay.io in the [openshift-scale](https://quay.io/organization/openshift-scale) organization. The builds will be triggered by any commit pushed to this repository.
+
+### Run containerized version
+Refer to the [instructions](https://github.com/openshift-scale/cerberus#Run-containerized-version) for information on how to build and run the containerized version of cerberus.


### PR DESCRIPTION
This commit adds support to run the tool as a container on the host
with access to kubeconfig for better portability. The plan is to add
a webhook to trigger image builds on every commit to this repo at
quay.io to make sure it has the latest code instead of the user
taking care of building the image manually.