### PR TITLE
Run http server on 0.0.0.0 instead of localhost

### DIFF
--- a/src/cerberus.py
+++ b/src/cerberus.py
@@ -109,7 +109,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
 
 def start_server():
-    httpd = HTTPServer(('localhost', 8086), SimpleHTTPRequestHandler)
+    httpd = HTTPServer(('0.0.0.0', 8080), SimpleHTTPRequestHandler)
     httpd.serve_forever()
 
 
@@ -170,7 +170,7 @@ def main(cfg):
         # if cerberus is asked to publish the status.
         # It is served by the http server.
         if cerberus_publish_status == "True":
-            logging.info("Publishing cerberus status at http://localhost:8086")
+            logging.info("Publishing cerberus status at http://0.0.0.0:8080")
             _thread.start_new_thread(start_server, ())
 
         # Initialize the start iteration to 0


### PR DESCRIPTION
This commit:
- Modifies the http server to listen on 0.0.0.0 to be able to query
  for the go/no-go signal using the public hostname/ip of the host
  on which the tool is running.
- Adds chaos testing for OpenShift as a use case.