### PR TITLE
Increase max line length in flake config to 100

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands = {posargs}
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.
 show-source = True
+max-line-length = 100
 ignore = E123,E125
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
with indentation and the names of namespace being long, 79 chars more often than not is insufficient.

Note: PyCharm has a default of 120 chars