### PR TITLE
Monitor any given namespace

### DIFF
--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -77,3 +77,12 @@ def monitor_namespace(namespace):
     else:
         status = True
     return status, notready_pods
+
+
+# Monitor component namespace
+def monitor_component(iteration, component_namespace):
+    watch_component_status, failed_component_pods = \
+        monitor_namespace(component_namespace)
+    logging.info("Iteration %s: %s: %s"
+                 % (iteration, component_namespace, watch_component_status))
+    return watch_component_status, failed_component_pods

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,26 +1,17 @@
 cerberus:
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
-    watch_etcd: True                                     # Set to True for the cerberus to monitor the etcd members
-    etcd_namespace: openshift-etcd                       # Namespace to look for the etcd member pods
-    watch_openshift_apiserver: True                      # Set to True for the cerberus to monitor openshift-apiserver pods
-    openshift_apiserver_namespace: openshift-apiserver   # Namespace to look for the openshift-apiserver pods
-    watch_kube_apiserver: True                           # Set to True for the cerberus to monitor openshift-apiserver pods
-    kube_apiserver_namespace: openshift-kube-apiserver   # Namespace to look for the kube-apiserver pods
-    watch_monitoring_stack: True                         # Set to True for the cerberus to monitor prometheus/monitoring stack pods
-    monitoring_stack_namespace: openshift-monitoring     # Namespace to look for the monitoring stack pods
-    watch_kube_controller: True                          # Set to True for the cerberus to monitor kube-controller
-    kube_controller_namespace: openshift-kube-controller # Namespace to look for the kube controller pods
-    watch_machine_api_components: True                   # Set to True for the cerberus to monitor machine api components
-    machine_api_namespace: openshift-machine-api         # Namespace to look for the Machine API components
-    watch_kube_scheduler: True                           # Set to True for the cerberus to monitor kube-scheduler
-    kube_scheduler_namespace: openshift-kube-scheduler   # Namespace to look for the kube scheduler pods
-    watch_openshift_ingress: True                        # Set to True for the cerberus to monitor openshift-ingress
-    openshift_ingress_namespace: openshift-ingress       # Namespace to look for the openshift ingress pods
-    watch_openshift_sdn: True                            # Set to True for the cerberus to monitor openshift-sdn
-    openshift_sdn_namespace: openshift-sdn               # Namespace to look for the openshift-sdn pods
-    watch_ovnkubernetes: False                           # Set to True for the cerberus to monitor ovn kubernetes components
-    ovn_namespace: openshift-ovn-kubernetes              # Namespace to look for the OVNKubernetes pods
+    watch_namespaces:                                    # List of namespaces to be monitored
+        -    openshift-etcd
+        -    openshift-apiserver
+        -    openshift-kube-apiserver
+        -    openshift-monitoring
+        -    openshift-kube-controller
+        -    openshift-machine-api
+        -    openshift-kube-scheduler
+        -    openshift-ingress
+        -    openshift-sdn
+        -    openshift-ovn-kubernetes
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -29,33 +29,7 @@ def main(cfg):
         watch_nodes = config["cerberus"]["watch_nodes"]
         cerberus_publish_status = \
             config["cerberus"]["cerberus_publish_status"]
-        watch_etcd = config["cerberus"]["watch_etcd"]
-        etcd_namespace = config["cerberus"]["etcd_namespace"]
-        watch_openshift_apiserver = \
-            config["cerberus"]["watch_openshift_apiserver"]
-        openshift_apiserver_namespace = \
-            config["cerberus"]["openshift_apiserver_namespace"]
-        watch_kube_apiserver = config["cerberus"]["watch_kube_apiserver"]
-        kube_apiserver_namespace = \
-            config["cerberus"]["kube_apiserver_namespace"]
-        watch_monitoring_stack = config["cerberus"]["watch_monitoring_stack"]
-        monitoring_stack_namespace = \
-            config["cerberus"]["monitoring_stack_namespace"]
-        watch_kube_controller = config["cerberus"]["watch_kube_controller"]
-        kube_controller_namespace = \
-            config["cerberus"]["kube_controller_namespace"]
-        watch_machine_api = config["cerberus"]["watch_machine_api_components"]
-        machine_api_namespace = config["cerberus"]["machine_api_namespace"]
-        watch_kube_scheduler = config["cerberus"]["watch_kube_scheduler"]
-        kube_scheduler_namespace = \
-            config["cerberus"]["kube_scheduler_namespace"]
-        watch_openshift_ingress = config["cerberus"]["watch_openshift_ingress"]
-        openshift_ingress_namespace = \
-            config["cerberus"]["openshift_ingress_namespace"]
-        watch_openshift_sdn = config["cerberus"]["watch_openshift_sdn"]
-        openshift_sdn_namespace = config["cerberus"]["openshift_sdn_namespace"]
-        watch_ovnkubernetes = config["cerberus"]["watch_ovnkubernetes"]
-        ovn_namespace = config["cerberus"]["ovn_namespace"]
+        watch_namespaces = config["cerberus"]["watch_namespaces"]
         kubeconfig_path = config["cerberus"]["kubeconfig_path"]
         iterations = config["tunings"]["iterations"]
         sleep_time = config["tunings"]["sleep_time"]
@@ -113,128 +87,17 @@ def main(cfg):
                              "assuming that the nodes are ready")
                 watch_nodes_status = True
 
-            # Monitor etcd status
-            if watch_etcd:
-                watch_etcd_status, failed_etcd_pods = \
-                    kubecli.monitor_namespace(etcd_namespace)
-                logging.info("Iteration %s: Etcd member pods status: %s"
-                             % (iteration, watch_etcd_status))
-            else:
-                logging.info("Cerberus is not monitoring ETCD, "
-                             "so setting the status to True and "
-                             "assuming that the ETCD member pods are ready")
-                watch_etcd_status = True
+            # Monitor each component in the namespace
+            # Set the initial cerberus_status
+            failed_pods_components = {}
+            cerberus_status = True
 
-            # Monitor openshift-apiserver status
-            if watch_openshift_apiserver:
-                watch_openshift_apiserver_status, failed_ocp_apiserver_pods = \
-                    kubecli.monitor_namespace(openshift_apiserver_namespace)
-                logging.info("Iteration %s: OpenShift apiserver status: %s"
-                             % (iteration, watch_openshift_apiserver_status))
-            else:
-                logging.info("Cerberus is not monitoring openshift-apiserver, "
-                             "so setting the status to True "
-                             "and assuming that the "
-                             "openshift-apiserver is up and running")
-                watch_openshift_apiserver_status = True
-
-            # Monitor kube apiserver status
-            if watch_kube_apiserver:
-                watch_kube_apiserver_status, failed_kube_apiserver_pods = \
-                    kubecli.monitor_namespace(kube_apiserver_namespace)
-                logging.info("Iteration %s: Kube ApiServer status: %s"
-                             % (iteration, watch_kube_apiserver_status))
-            else:
-                logging.info("Cerberus is not monitoring Kube ApiServer, so "
-                             "setting the status to True and assuming that "
-                             "the Kube ApiServer is up and running")
-                watch_kube_apiserver_status = True
-
-            # Monitor prometheus/monitoring stack
-            if watch_monitoring_stack:
-                watch_monitoring_stack_status, failed_monitoring_stack = \
-                    kubecli.monitor_namespace(monitoring_stack_namespace)
-                logging.info("Iteration %s: Monitoring stack status: %s"
-                             % (iteration, watch_monitoring_stack_status))
-            else:
-                logging.info("Cerberus is not monitoring prometheus stack, "
-                             "so setting the status to True "
-                             "and assuming that the monitoring stack is "
-                             "up and running")
-                watch_monitoring_stack_status = True
-
-            # Monitor kube controller
-            if watch_kube_controller:
-                watch_kube_controller_status, failed_kube_controller_pods = \
-                    kubecli.monitor_namespace(kube_controller_namespace)
-                logging.info("Iteration %s: Kube controller status: %s"
-                             % (iteration, watch_kube_controller_status))
-            else:
-                logging.info("Cerberus is not monitoring kube controller, so "
-                             "setting the status to True and assuming that "
-                             "the kube controller is up and running")
-                watch_kube_controller_status = True
-
-            # Monitor machine api components
-            # Components includes operator, controller and auto scaler
-            if watch_machine_api:
-                watch_machine_api_status, failed_machine_api_components = \
-                    kubecli.monitor_namespace(machine_api_namespace)
-                logging.info("Iteration %s: Machine API components status: %s"
-                             % (iteration, watch_machine_api_status))
-            else:
-                logging.info("Cerberus is not monitoring machine api "
-                             "components, so setting the status to True and "
-                             "assuming that it is up and running")
-                watch_machine_api_status = True
-
-            # Monitor kube scheduler
-            if watch_kube_scheduler:
-                watch_kube_scheduler_status, failed_kube_scheduler_pods = \
-                    kubecli.monitor_namespace(kube_scheduler_namespace)
-                logging.info("Iteration %s: Kube scheduler status: %s"
-                             % (iteration, watch_kube_scheduler_status))
-            else:
-                logging.info("Cerberus is not monitoring kube scheduler, so "
-                             "setting the status to True and assuming that "
-                             "the kube scheduler is up and running")
-                watch_kube_scheduler_status = True
-
-            # Monitor openshift-ingress status
-            if watch_openshift_ingress:
-                watch_openshift_ingress_status, failed_ocp_ingress_pods = \
-                    kubecli.monitor_namespace(openshift_ingress_namespace)
-                logging.info("Iteration %s: OpenShift ingress status: %s"
-                             % (iteration, watch_openshift_ingress_status))
-            else:
-                logging.info("Cerberus is not monitoring openshift-ingress, "
-                             "so setting the status to True "
-                             "and assuming that the "
-                             "openshift-ingress is up and running")
-                watch_openshift_ingress_status = True
-
-            # Monitor openshift-sdn status
-            if watch_openshift_sdn:
-                watch_openshift_sdn_status, failed_ocp_sdn_pods = \
-                    kubecli.monitor_namespace(openshift_sdn_namespace)
-                logging.info("Iteration %s: OpenShift SDN status: %s"
-                             % (iteration, watch_openshift_sdn_status))
-            else:
-                logging.info("Cerberus is not monitoring openshift-sdn, "
-                             "assuming it is up and running")
-                watch_openshift_sdn_status = True
-
-            # Monitor openshift-ovn-kubernetes status
-            if watch_ovnkubernetes:
-                watch_ovnkubernetes_status, failed_ovnkubernetes_pods = \
-                    kubecli.monitor_namespace(ovn_namespace)
-                logging.info("Iteration %s: OpenShift OVN status: %s"
-                             % (iteration, watch_ovnkubernetes_status))
-            else:
-                logging.info("Cerberus is not monitoring "
-                             "openshift-ovn-kubernetes, "
-                             "assuming it is up and running")
-                watch_ovnkubernetes_status = True
+            for namespace in watch_namespaces:
+                watch_component_status, failed_component_pods = \
+                    kubecli.monitor_component(iteration, namespace)
+                cerberus_status = cerberus_status and watch_component_status
+                if not watch_component_status:
+                    failed_pods_components[namespace] = failed_component_pods
 
             # Check for the number of hits
             if cerberus_publish_status:
@@ -246,55 +109,15 @@ def main(cfg):
             logging.info("Sleeping for the "
                          "specified duration: %s" % (sleep_time))
             time.sleep(float(sleep_time))
-            # Set the cerberus status by checking the status of the
-            # watched components/resources for the http server to publish it
-            if watch_nodes_status and watch_etcd_status \
-                and watch_openshift_apiserver_status \
-                and watch_kube_apiserver_status \
-                and watch_monitoring_stack_status \
-                and watch_kube_controller_status \
-                and watch_machine_api_status \
-                and watch_openshift_ingress_status \
-                and watch_kube_scheduler_status \
-                and watch_openshift_sdn_status \
-                and watch_ovnkubernetes_status:
-                cerberus_status = True
-            else:
-                cerberus_status = False
-                print("+{}Failed Components{}+".format("-" * (50), "-" * (50)))
-                if not watch_nodes_status:
-                    logging.info("Failed nodes: %s\n"
-                                 % (failed_nodes))
-                if not watch_etcd_status:
-                    logging.info("Failed etcd pods: %s\n"
-                                 % (failed_etcd_pods))
-                if not watch_openshift_apiserver_status:
-                    logging.info("Failed openshift apiserver pods: %s\n"
-                                 % (failed_ocp_apiserver_pods))
-                if not watch_kube_apiserver:
-                    logging.info("Failed kube apiserver pods: %s\n"
-                                 % (failed_kube_apiserver_pods))
-                if not watch_monitoring_stack_status:
-                    logging.info("Failed monitoring stack components: %s\n"
-                                 % (failed_monitoring_stack))
-                if not watch_kube_controller_status:
-                    logging.info("Failed kube controller pods: %s\n"
-                                 % (failed_kube_controller_pods))
-                if not watch_machine_api_status:
-                    logging.info("Failed machine api components: %s\n"
-                                 % (failed_machine_api_components))
-                if not watch_openshift_ingress_status:
-                    logging.info("Failed ingress components: %s\n"
-                                 % (failed_ocp_ingress_pods))
-                if not watch_kube_scheduler_status:
-                    logging.info("Failed kube scheduler pods: %s\n"
-                                 % (failed_kube_scheduler_pods))
-                if not watch_openshift_sdn_status:
-                    logging.info("Failed openshfit sdn components: %s\n"
-                                 % (failed_ocp_sdn_pods))
-                if not watch_ovnkubernetes_status:
-                    logging.info("Failed ocnkubernetes components: %s\n"
-                                 % (failed_ovnkubernetes_pods))
+
+            # Logging the failed components
+            if not watch_nodes_status:
+                logging.info("Failed nodes: %s \n" % (failed_nodes))
+
+            if not cerberus_status:
+                logging.info("Failed pods and components")
+                for namespace, failures in failed_pods_components.items():
+                    logging.info("%s: %s", namespace, failures)
 
             if cerberus_publish_status:
                 publish_cerberus_status(cerberus_status)


### PR DESCRIPTION
This PR solves: #17  
This PR is a continuation of #18
A single function named monitor_component() can be used to
monitor any namespace thereby preventing code redundancy.