### PR TITLE
Collects logs, events and metrics of failed components

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ cerberus:
         -    openshift-sdn
         -    openshift-ovn-kubernetes
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
+    inspect_components: False                            # Enable it only when OpenShift client is supported to run.
+                                                         # When enabled, cerberus collects logs, events and metrics of failed components
+
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,6 +13,8 @@ cerberus:
         -    openshift-sdn
         -    openshift-ovn-kubernetes
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
+    inspect_components: False                            # Enable it only when OpenShift client is supported to run.
+                                                         # When enabled, cerberus collects logs, events and metrics of failed components
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration


### PR DESCRIPTION
This PR solves: #21 
The commit enables the Cerberus tool to collect logs, metrics
and events relevant to the components when there's a failure.
Eventually, the collected data can be exposed by the http
server along with the go/no-go signal.