### PR TITLE
Updated Dockerfile and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Assuming that the latest docker ( 17.05 or greater with multi-build support ) is
 ```
 $ cd containers
 $ docker pull quay.io/openshift-scale/cerberus
-$ docker run --name=cerberus --net=host -v <path_to_kubeconfig>:/root/.kube/config -v <path_to_cerberus_config>:/root/cerberus/config/config.ini -d cerberus:latest
+$ docker run --name=cerberus --net=host -v <path_to_kubeconfig>:/root/.kube/config -v <path_to_cerberus_config>:/root/cerberus/config/config.yaml -d quay.io/openshift-scale/cerberus:latest
 $ docker logs -f cerberus
 ```
 
@@ -60,7 +60,7 @@ Similarly, podman can be used to achieve the same:
 ```
 $ cd containers
 $ podman pull quay.io/openshift-scale/cerberus
-$ podman run --name=cerberus --net=host -v <path_to_kubeconfig>:/root/.kube/config:Z -v <path_to_cerberus_config>:/root/cerberus/config/config.ini:Z -d cerberus:latest
+$ podman run --name=cerberus --net=host -v <path_to_kubeconfig>:/root/.kube/config:Z -v <path_to_cerberus_config>:/root/cerberus/config/config.yaml:Z -d quay.io/openshift-scale/cerberus:latest
 $ podman logs -f cerberus
 ```
 The go/no-go signal ( True or False ) gets published at http://<hostname>:8080. Note that the cerberus will only support ipv4 for the time being.

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -20,4 +20,4 @@ pip3 install -r requirements.txt
 
 WORKDIR /root/cerberus
 
-ENTRYPOINT python3 start_cerberus.py --config=config/config.ini
+ENTRYPOINT python3 start_cerberus.py --config=config/config.yaml


### PR DESCRIPTION
This commit:
- Modifies the Dockerfile to change the config file type from
  ini to yaml.
- Updates README.md file to create a container using the image
  quay.io/openshift-scale/cerberus:latest instead of cerberus:latest.
  This prevents the podman/docker from creating a container using
  cerberus:latest image that might be present on the machine it's
  running. The images quay.io/openshift-scale/cerberus:latest and
  cerberus:latest could be different.