### PR TITLE
Added support for cerberus cop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ cerberus:
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run.
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
-    slack_integration: False                             # When enabled, cerberus reports status of each iteration in slack channel
+    slack_integration: False                             # When enabled, cerberus reports status of failed iterations on a slack channel
 
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
 
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+cop_slack_ID:                                            # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
+    Monday:
+    Tuesday:
+    Wednesday:
+    Thursday:
+    Friday:
 ```
 NOTE: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.
 
@@ -115,11 +122,10 @@ The report is generated in the run directory and it contains the information abo
 ```
 
 #### Slack integration
-The user has the option to enable/disable the slack integration. To use the slack integration, the user has to first create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Two env variables SLACK_API_TOKEN and SLACK_CHANNEL have to be set. SLACK_API_TOKEN refers to Bot User OAuth Access Token and SLACK_CHANNEL refers to the slack channel the user wishes to receive the notifications in. When enabled, cerberus reports the following on slack:
-- Notifies the start of cerberus monitoring.
-- Notifies the status of each iteration.
-- Sends the cerberus report at the end of an iteration in case of a failure.
-- Sends the cerberus report after completion of specified number of iterations set by the user.
+The user has the option to enable/disable the slack integration. To use the slack integration, the user has to first create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. Two env variables SLACK_API_TOKEN and SLACK_CHANNEL have to be set. SLACK_API_TOKEN refers to Bot User OAuth Access Token and SLACK_CHANNEL refers to the slack channel ID the user wishes to receive the notifications in.
+- Reports the start of cerberus monitoring on a slack channel.
+- Reports the component failures in different clusters on a slack channel.
+- A cop can be assigned for each day. The cop of the day is tagged while reporting failures on a slack channel. (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
 
 #### Go or no-go signal
 When the cerberus is configured to run in the daemon mode, it will continuosly monitor the components specified, runs a simple http server at http://0.0.0.0:8080 and publishes the signal i.e True or False depending on the components status. The tools can consume the signal and act accordingly.

--- a/cerberus/slack/slack_client.py
+++ b/cerberus/slack/slack_client.py
@@ -4,23 +4,23 @@ import os
 
 # Load env variables and initialize slack python client
 def initialize_slack_client():
-    global slack_client, slack_reporter_token, slack_channel_name
+    global slack_reporter_token, slack_channel_ID, slack_client
     slack_reporter_token = os.environ["SLACK_API_TOKEN"]
-    slack_channel_name = os.environ["SLACK_CHANNEL"]
+    slack_channel_ID = os.environ["SLACK_CHANNEL"]
     slack_client = slack.WebClient(token=slack_reporter_token)
 
 
 # Post messages and failures in slack
 def post_message_in_slack(slack_message):
     slack_client.chat_postMessage(
-        channel=slack_channel_name,
+        channel=slack_channel_ID,
+        link_names=True,
         text=slack_message
     )
 
 
-# Post cerberus report in slack
-def post_file_in_slack():
-    slack_client.files_upload(
-        channels=slack_channel_name,
-        file="cerberus.report"
+# Get members of a channel
+def get_channel_members():
+    return slack_client.conversations_members(
+        channel=slack_channel_ID
     )

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,10 +15,17 @@ cerberus:
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
-    slack_integration: False                             # When enabled, cerberus reports status of each iteration in slack channel
+    slack_integration: False                             # When enabled, cerberus reports the failed iterations on a slack channel
 
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
 
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+cop_slack_ID:                                            # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
+    Monday:
+    Tuesday:
+    Wednesday:
+    Thursday:
+    Friday:


### PR DESCRIPTION
This PR solves issue: #32 
 
This commit enables cop id's to be assigned for each day in config
file. The cop for the day is tagged while reporting cluster component
failures. If a cop isn't assigned or if the assinged cop isn't a
member of the slack channel or if a wrong slack member id is
provided, everyone on the channel is notified by using @here tag.