### PR TITLE
add node problem detector

### DIFF
--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -39,6 +39,7 @@ def list_pods(namespace):
 def monitor_nodes():
     nodes = list_nodes()
     notready_nodes = []
+    node_kerneldeadlock_status = False
     for node in nodes:
         try:
             node_info = cli.read_node_status(node, pretty=True)
@@ -46,17 +47,35 @@ def monitor_nodes():
             logging.error("Exception when calling \
                            CoreV1Api->read_node_status: %s\n" % e)
         for condition in node_info.status.conditions:
-            if condition.type == "Ready":
-                node_status = condition.status
+            if condition.type == "KernelDeadlock":
+                node_kerneldeadlock_status = condition.status
+            elif condition.type == "Ready":
+                node_ready_status = condition.status
             else:
                 continue
-        if node_status != "True":
+        if (
+            node_kerneldeadlock_status != "False"        # noqa
+            or node_ready_status != "True"               # noqa
+        ):
             notready_nodes.append(node)
     if len(notready_nodes) != 0:
         status = False
     else:
         status = True
     return status, notready_nodes
+
+
+# Check the namespace name for default SDN
+def check_sdn_namespace():
+    for item in cli.list_namespace().items:
+        if item.metadata.name == "openshift-ovn-kubernetes":
+            return "openshift-ovn-kubernetes"
+        elif item.metadata.name == "openshift-sdn":
+            return "openshift-sdn"
+        else:
+            continue
+    logging.error("Could not find openshift-sdn and openshift-ovn-kubernetes namespaces, \
+        please specify the correct networking namespace in config file")
 
 
 # Monitor the status of the pods in the specified namespace

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,8 +10,7 @@ cerberus:
         -    openshift-machine-api
         -    openshift-kube-scheduler
         -    openshift-ingress
-        -    openshift-sdn
-        -    openshift-ovn-kubernetes
+        -    openshift-sdn                               # When enabled, it will check for the cluster sdn and monitor that namespace
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components


### PR DESCRIPTION
@chaitanyaenr 
when [node problem detector](https://github.com/kubernetes/node-problem-detector) daemon is present in `openshift-node-problem-detector` namespace.  It will be able to monitor additional node conditions like KernelDeadlock and ReadonlyFilesystem


when openshift-node-problem-detector detects a problem with the node
```
2020-04-06 16:51:22,165 [INFO] Iteration 37: Node status: False
2020-04-06 16:51:22,196 [INFO] Iteration 37: openshift-etcd: True
2020-04-06 16:51:22,224 [INFO] Iteration 37: openshift-apiserver: True
2020-04-06 16:51:22,504 [INFO] Iteration 37: openshift-kube-apiserver: True
2020-04-06 16:51:22,722 [INFO] Iteration 37: openshift-monitoring: False
2020-04-06 16:51:22,727 [INFO] Iteration 37: openshift-kube-controller: True
2020-04-06 16:51:22,754 [INFO] Iteration 37: openshift-machine-api: True
2020-04-06 16:51:22,898 [INFO] Iteration 37: openshift-kube-scheduler: True
2020-04-06 16:51:22,917 [INFO] Iteration 37: openshift-ingress: True
2020-04-06 16:51:23,095 [INFO] Iteration 37: openshift-sdn: True
2020-04-06 16:51:23,100 [INFO] Iteration 37: openshift-ovn-kubernetes: True
2020-04-06 16:51:23,173 [INFO] Iteration 37: openshift-node-problem-detector: True
2020-04-06 16:51:23,173 [INFO] HTTP requests served: 0 

2020-04-06 16:51:23,173 [INFO] Failed nodes
2020-04-06 16:51:23,173 [INFO] ['ip-10-0-6-109.us-west-2.compute.internal']
2020-04-06 16:51:23,173 [INFO] Failed pods and components
2020-04-06 16:51:23,173 [INFO] openshift-monitoring: ['cluster-monitoring-operator-85cbc8877c-qs8gs']
```


when cerberus detects problem with openshift-node-problem-detector

```
2020-04-06 16:50:20,713 [INFO] Iteration 27: Node status: True
2020-04-06 16:50:20,745 [INFO] Iteration 27: openshift-etcd: True
2020-04-06 16:50:20,774 [INFO] Iteration 27: openshift-apiserver: True
2020-04-06 16:50:21,084 [INFO] Iteration 27: openshift-kube-apiserver: True
2020-04-06 16:50:21,306 [INFO] Iteration 27: openshift-monitoring: False
2020-04-06 16:50:21,310 [INFO] Iteration 27: openshift-kube-controller: True
2020-04-06 16:50:21,336 [INFO] Iteration 27: openshift-machine-api: True
2020-04-06 16:50:21,488 [INFO] Iteration 27: openshift-kube-scheduler: True
2020-04-06 16:50:21,507 [INFO] Iteration 27: openshift-ingress: True
2020-04-06 16:50:21,685 [INFO] Iteration 27: openshift-sdn: True
2020-04-06 16:50:21,689 [INFO] Iteration 27: openshift-ovn-kubernetes: True
2020-04-06 16:50:21,764 [INFO] Iteration 27: openshift-node-problem-detector: False
2020-04-06 16:50:21,764 [INFO] HTTP requests served: 0 

2020-04-06 16:50:21,764 [INFO] Failed pods and components
2020-04-06 16:50:21,764 [INFO] openshift-monitoring: ['cluster-monitoring-operator-85cbc8877c-qs8gs'] 

2020-04-06 16:50:21,764 [INFO] openshift-node-problem-detector: ['node-problem-detector-8x8cz'] 

2020-04-06 16:50:21,765 [INFO] Sleeping for the specified duration: 5
```