### PR TITLE
cerberus status is dumped to a json file

### DIFF
--- a/cerberus/server/server.py
+++ b/cerberus/server/server.py
@@ -11,7 +11,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.end_headers()
-        f = open('/tmp/cerberus_status', 'rb')
+        f = open('/tmp/cerberus_status.json', 'rb')
         self.wfile.write(f.read())
         SimpleHTTPRequestHandler.requests_served = \
             SimpleHTTPRequestHandler.requests_served + 1

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,16 +17,15 @@ cerberus:
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
     slack_integration: False                             # When enabled, cerberus reports the failed iterations on a slack channel
                                                          # SLACK_API_TOKEN ( Bot User OAuth Access Token ) and SLACK_CHANNEL ( channel to send notifications in case of failures )
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+    cop_slack_ID:                                        # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
+        Monday:
+        Tuesday:
+        Wednesday:
+        Thursday:
+        Friday:
 
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
-
-                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
-cop_slack_ID:                                            # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
-    Monday:
-    Tuesday:
-    Wednesday:
-    Thursday:
-    Friday:

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -6,6 +6,7 @@ import time
 import optparse
 import logging
 import yaml
+import json
 import cerberus.kubernetes.client as kubecli
 import cerberus.slack.slack_client as slackcli
 import cerberus.invoke.command as runcommand
@@ -14,8 +15,8 @@ import pyfiglet
 
 # Publish the cerberus status
 def publish_cerberus_status(status):
-    with open('/tmp/cerberus_status', 'w+') as file:
-        file.write(str(status))
+    with open('/tmp/cerberus_status.json', 'w+') as file:
+        json.dump({'cerberus_status': str(status)}, file)
 
 
 # Main function
@@ -100,7 +101,7 @@ def main(cfg):
 
             if slack_integration:
                 weekday = runcommand.invoke("date '+%A'")[:-1]
-                cop_slack_member_ID = config['cop_slack_ID'][weekday]
+                cop_slack_member_ID = config["cerberus"]['cop_slack_ID'][weekday]
                 valid_cops = slackcli.get_channel_members()['members']
 
                 if iteration == 1:


### PR DESCRIPTION
This commit:
- Dumps the cerberus status to a json file instead of a text file.
- Places the cop_slack_ID key value pairs under cerberus key in
  the config file.