### PR TITLE
Added support for slack_team_alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,23 @@ cerberus:
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run.
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
-    slack_integration: False                             # When enabled, cerberus reports status of failed iterations on a slack channel
+    slack_integration: False                             # When enabled, cerberus reports status of failed iterations in the slack channel
                                                          # SLACK_API_TOKEN ( Bot User OAuth Access Token ) and SLACK_CHANNEL ( channel to send notifications in case of failures )
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in the slack channel. Values are slack member ID's.
+    cop_slack_ID:                                        # (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
+        Monday:
+        Tuesday:
+        Wednesday:
+        Thursday:
+        Friday:
+        Saturday:
+        Sunday:
+    slack_team_alias:                                    # The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned
 
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
-
-                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
-cop_slack_ID:                                            # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
-    Monday:
-    Tuesday:
-    Wednesday:
-    Thursday:
-    Friday:
 ```
 NOTE: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.
 
@@ -121,7 +123,7 @@ The report is generated in the run directory and it contains the information abo
 The user has the option to enable/disable the slack integration ( disabled by default ). To use the slack integration, the user has to first create an [app](https://api.slack.com/apps?new_granular_bot_app=1) and add a bot to it on slack. SLACK_API_TOKEN and SLACK_CHANNEL environment variables have to be set. SLACK_API_TOKEN refers to Bot User OAuth Access Token and SLACK_CHANNEL refers to the slack channel ID the user wishes to receive the notifications.
 - Reports when cerberus starts monitoring a cluster in the specified slack channel.
 - Reports the component failures in the slack channel.
-- A cop can be assigned for each day of the week. The cop of the day is tagged while reporting failures on a slack channel instead of everyone. (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
+- A cop can be assigned for each day of the week. The cop of the day is tagged while reporting failures in the slack channel instead of everyone. (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
 
 #### Go or no-go signal
 When the cerberus is configured to run in the daemon mode, it will continuosly monitor the components specified, runs a simple http server at http://0.0.0.0:8080 and publishes the signal i.e True or False depending on the components status. The tools can consume the signal and act accordingly.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,18 +14,20 @@ cerberus:
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
     inspect_components: False                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
-    slack_integration: False                             # When enabled, cerberus reports the failed iterations on a slack channel
+    slack_integration: False                             # When enabled, cerberus reports the failed iterations in the slack channel
                                                          # SLACK_API_TOKEN ( Bot User OAuth Access Token ) and SLACK_CHANNEL ( channel to send notifications in case of failures )
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in the slack channel. Values are slack member ID's.
+    cop_slack_ID:                                        # (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
+        Monday:
+        Tuesday:
+        Wednesday:
+        Thursday:
+        Friday:
+        Saturday:
+        Sunday:
+    slack_team_alias:                                    # The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned
 
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
-
-                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
-cop_slack_ID:                                            # (Note: Defining the cop id's is optional and when the cop slack id's are not defined, the failure messages are sent to the slack channel with "@here" to tag everyone.)
-    Monday:
-    Tuesday:
-    Wednesday:
-    Thursday:
-    Friday:

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -104,15 +104,21 @@ def main(cfg):
 
             if slack_integration:
                 weekday = runcommand.invoke("date '+%A'")[:-1]
-                cop_slack_member_ID = config['cop_slack_ID'][weekday]
+                cop_slack_member_ID = config["cerberus"]["cop_slack_ID"][weekday]
                 valid_cops = slackcli.get_channel_members()['members']
+                slack_team_alias = config["cerberus"]["slack_team_alias"]
+
+                if cop_slack_member_ID in valid_cops:
+                    slack_tag = "<@" + cop_slack_member_ID + ">"
+                elif slack_team_alias:
+                    slack_tag = "@" + slack_team_alias + " "
+                else:
+                    slack_tag = ""
 
                 if iteration == 1:
                     if cop_slack_member_ID in valid_cops:
-                        slack_tag = "Hi <@" + cop_slack_member_ID + ">! The cop " \
+                        slack_tag = "Hi " + slack_tag + "! The cop " \
                                     "for " + weekday + "!\n"
-                    else:
-                        slack_tag = "@here "
                     slackcli.post_message_in_slack(slack_tag + "Cerberus has started monitoring! "
                                                    ":skull_and_crossbones: %s" % (cluster_info))
 
@@ -158,14 +164,6 @@ def main(cfg):
                     failed_namespaces = ", ".join(list(failed_pods_components.keys()))
                     valid_cops = slackcli.get_channel_members()['members']
                     cerberus_report_path = runcommand.invoke("pwd | tr -d '\n'")
-                    if cop_slack_member_ID in valid_cops:
-                        # If the cop assigned is a member of the slack channel, tag the cop
-                        # while reporting every failure
-                        slack_tag = "<@" + cop_slack_member_ID + ">"
-                    else:
-                        # If a cop isn't assigned for the day, tag everyone by using @here
-                        # while reporting every failure
-                        slack_tag = "@here"
                     slackcli.post_message_in_slack(slack_tag + " %sIn iteration %d, cerberus "
                                                    "found issues in namespaces: *%s*. Hence, "
                                                    "setting the go/no-go signal to false. The "


### PR DESCRIPTION
When the cop slack id's are not defined, the slack_team_alias tag
is used while reporting failures in the slack channel if the
slack_team_alias tag is set in the config.