### PR TITLE
Adding watch of Cluster operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Set the supported components to monitor and the tunings like number of iteration
 cerberus:
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
+    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
         -    openshift-apiserver
@@ -166,6 +167,7 @@ Kube Scheduler           | Watches Kube scheduler                               
 Ingress                  | Watches Routers                                                                                    | :heavy_check_mark:        |
 Openshift SDN            | Watches SDN pods                                                                                   | :heavy_check_mark:        |
 OVNKubernetes            | Watches OVN pods                                                                                   | :heavy_check_mark:        |
+Cluster Operators        | Watches all Cluster Operators                                                                      | :heavy_check_mark:        |
 
 NOTE: It supports monitoring pods in any namespaces specified in the config, the watch is enabled for system components mentioned above by default as they are critical for running the operations on Kubernetes/OpenShift clusters.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,7 @@
 cerberus:
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
+    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
         -    openshift-apiserver

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -31,6 +31,7 @@ def main(cfg):
         with open(cfg, 'r') as f:
             config = yaml.full_load(f)
         watch_nodes = config["cerberus"]["watch_nodes"]
+        watch_cluster_operators = config["cerberus"].get("watch_cluster_operators", True)
         cerberus_publish_status = config["cerberus"]["cerberus_publish_status"]
         watch_namespaces = config["cerberus"]["watch_namespaces"]
         kubeconfig_path = config["cerberus"]["kubeconfig_path"]
@@ -111,6 +112,19 @@ def main(cfg):
                              "to True and assuming that the nodes are ready")
                 watch_nodes_status = True
 
+            # Monitor cluster operators status
+            if watch_cluster_operators:
+                status_yaml = kubecli.get_cluster_operators()
+                watch_cluster_operators_status, failed_operators = \
+                    kubecli.monitor_cluster_operator( status_yaml)
+                logging.info("Iteration %s: Cluster Operator status: %s"
+                             % (iteration, watch_cluster_operators_status))
+            else:
+                logging.info("Cerberus is not monitoring cluster operators, "
+                             "so setting the status to True and "
+                             "assuming that the cluster operators are ready")
+                watch_cluster_operators_status = True
+
             # Monitor each component in the namespace
             failed_pods_components = {}
             failed_pod_containers = {}
@@ -134,6 +148,10 @@ def main(cfg):
                 logging.info("Failed nodes")
                 logging.info("%s" % (failed_nodes))
 
+            if not watch_cluster_operators_status:
+                logging.info("Failed operators")
+                logging.info(failed_operators)
+
             if not watch_nodes_status or not watch_namespaces_status:
                 if not watch_namespaces_status:
                     logging.info("Failed pods and components")
@@ -150,7 +168,8 @@ def main(cfg):
             if inspect_components:
                 inspect.inspect_components(failed_pods_components)
 
-            cerberus_status = watch_nodes_status and watch_namespaces_status
+            cerberus_status = watch_nodes_status and watch_namespaces_status \
+                and watch_cluster_operators_status
 
             if cerberus_publish_status:
                 publish_cerberus_status(cerberus_status)


### PR DESCRIPTION
https://github.com/openshift-scale/cerberus/issues/43

This is a start for this issue.

I created a key that is optional in a config.yaml file. It will be set to false if it not in the yaml.
Only if the watch_operators key is set to true does it get the cluster operators and verify that the degraded status is False. If the status is not false it adds the operator to the failed list which gets returned to the start_cerberus.py file to log. 

I added the key to the README.md as well. 

I definitely could get rid of monitor_cluster_operators function, it is pretty much just passing the parameters around in an extra function.

Need to fix the output the I print out to be consistent with other outputs. With a colon and take out the extra space. (Another commit to come)

Definitely might consider taking out the printing of the degraded status for each operator every iteration and just show the failed ones. (See below of large output)

<img width="1045" alt="Screen Shot 2020-05-07 at 3 58 07 PM" src="https://user-images.githubusercontent.com/64206430/81339097-a4e3ef80-907b-11ea-8ec0-7955ec59df09.png">

