### PR TITLE
Fixed list_nodes, default config values, slack reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Once installed you will see node-problem-detector pods in openshift-node-problem
 Now enable openshift-node-problem-detector in the [config.yaml](https://github.com/openshift-scale/cerberus/blob/master/config/config.yaml).
 Cerberus just monitors `KernelDeadlock` condition provided by the node problem detector as it is system critical and can hinder node performance.
 
-#### Use cases
+### Use cases
 There can be number of use cases, here are some of them:
 - We run tools to push the limits of Kubernetes/OpenShift to look at the performance and scalability. There are a number of instances where system components or nodes start to degrade, which invalidates the results and the workload generator continues to push the cluster until it is unrecoverable.
 

--- a/cerberus/slack/slack_client.py
+++ b/cerberus/slack/slack_client.py
@@ -57,19 +57,20 @@ def slack_report_cerberus_start(cluster_info, weekday, cop_slack_member_ID):
 
 
 # Report the nodes and namespace failures in slack channel
-def slack_logging(cluster_info, iteration, watch_nodes_status, watch_namespaces_status,
-                  failed_nodes, failed_pods_components):
-    failed_nodes_list = ", ".join(failed_nodes)
-    failed_namespaces = ", ".join(list(failed_pods_components.keys()))
+def slack_logging(cluster_info, iteration, watch_nodes_status, failed_nodes,
+                  watch_cluster_operators_status, failed_operators,
+                  watch_namespaces_status, failed_pods_components):
+    issues = []
     cerberus_report_path = runcommand.invoke("pwd | tr -d '\n'")
-    if not watch_nodes_status and not watch_namespaces_status:
-        issues = "nodes: *" + failed_nodes_list + "* and in namespaces: *" + failed_namespaces + "*"
-    elif not watch_nodes_status:
-        issues = "nodes: *" + failed_nodes_list + "*"
-    else:
-        issues = "namespaces: *" + failed_namespaces + "*"
-    post_message_in_slack(slack_tag + " %sIn iteration %d, cerberus "
-                          "found issues in %s. Hence, setting the "
-                          "go/no-go signal to false. The full report "
+    if not watch_nodes_status:
+        issues.append("*nodes: " + ", ".join(failed_nodes) + "*")
+    if not watch_cluster_operators_status:
+        issues.append("*cluster operators: " + ", ".join(failed_operators) + "*")
+    if not watch_namespaces_status:
+        issues.append("*namespaces: " + ", ".join(list(failed_pods_components.keys())) + "*")
+    issues = "\n".join(issues)
+    post_message_in_slack(slack_tag + " %sIn iteration %d, Cerberus "
+                          "found issues in: \n%s \nHence, setting the "
+                          "go/no-go signal to false. \nThe full report "
                           "is at *%s* on the host cerberus is running."
                           % (cluster_info, iteration, issues, cerberus_report_path))


### PR DESCRIPTION
This commit:
- Enables the nodes with specific label_selector to be listed.
- Prevents Cerberus from erroring out when key-values are not
  set in the config
- Reports failed cluster operators in a slack channel