### PR TITLE
Added support to run Cerberus as a Kubernetes Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cerberus:
     watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified
     watch_url_routes:                                    # Route url's you want to monitor
         - - https://...
-          - Bearer ****                                  #This parameter is optional, specify authorization need for get call to route 
+          - Bearer ****                                  # This parameter is optional, specify authorization need for get call to route
         - - http://...
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
@@ -89,6 +89,9 @@ $ podman logs -f cerberus
 The go/no-go signal ( True or False ) gets published at http://`<hostname>`:8080. Note that the cerberus will only support ipv4 for the time being.
 
 **NOTE**: The report is generated at /root/cerberus/cerberus.report inside the container, it can mounted to a directory on the host in case we want to capture it.
+
+#### Run containerized Cerberus as a Kubernetes/OpenShift deployment
+Refer to the [instructions](https://github.com/openshift-scale/cerberus/blob/master/containers/README.md#cerberus-as-a-kubeapp) for information on how to run cerberus as a KubeApp.
 
 #### Report
 The report is generated in the run directory and it contains the information about each check/monitored component status per iteration with timestamps. It also displays information about the components in case of failure. For example:

--- a/containers/README.md
+++ b/containers/README.md
@@ -4,3 +4,21 @@ Container image gets automatically built by quay.io at [Cerberus image](https://
 
 ### Run containerized version
 Refer to the [instructions](https://github.com/openshift-scale/cerberus#Run-containerized-version) for information on how to build and run the containerized version of cerberus.
+
+### Cerberus as a KubeApp
+To run containerized Cerberus as a Kubernetes/OpenShift Deployment, follow these steps:
+1. Configure the [config.yaml](https://github.com/openshift-scale/cerberus/tree/master/config) file according to your requirements.
+2. Create a namespace under which you want to run the cerberus pod using `kubectl create ns <namespace>`.
+3. Switch to `<namespace>` namespace:
+    - In Kubernetes, use `kubectl config set-context --current --namespace=<namespace>`
+    - In OpenShift, use `oc project <namespace>`
+4. Create a ConfigMap named kube-config using `kubectl create configmap kube-config --from-file=<path_to_kubeconfig>`
+5. Create a ConfigMap named cerberus-config using `kubectl create configmap cerberus-config --from-file=<path_to_cerberus_config>`
+6. Create a serviceaccount to run the cerberus pod with privileges using `kubectl create serviceaccount useroot`.
+    - In Openshift, execute `oc adm policy add-scc-to-user privileged -z useroot`.
+7. Create a Deployment and a NodePort Service using `kubectl apply -f cerberus.yml`
+8. Accessing the go/no-go signal:
+    - In Kubernetes, execute `kubectl port-forward --address 0.0.0.0 pod/<cerberus_pod_name> 8080:8080` and access the signal at `http://localhost:8080` and `http://<hostname>:8080`.
+    - In Openshift, create a route based on service cerberus-service using `oc expose service cerberus-service`. List all the routes using `oc get routes`. Use HOST/PORT associated with cerberus-service to access the signal.
+
+NOTE: It is not recommended to run Cerberus internal to the cluster as the pod which is running Cerberus might get disrupted.

--- a/containers/cerberus.yml
+++ b/containers/cerberus.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cerberus-deployment
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      tool: Cerberus
+  template:
+    metadata:
+      labels:
+        tool: Cerberus
+    spec:
+      serviceAccountName: useroot
+      containers:
+        - name: cerberus
+          securityContext:
+            privileged: true
+          image: quay.io/openshift-scale/cerberus
+          command: ["/bin/sh", "-c"]
+          args: ["python3 start_cerberus.py -c config/config.yaml"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: "/root/.kube"
+              name: config
+            - mountPath: "/root/cerberus/config"
+              name: cerberus-config
+      volumes:
+        - name: config
+          configMap:
+            name: kube-config
+        - name: cerberus-config
+          configMap:
+            name: cerberus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cerberus-service
+spec:
+  type: NodePort
+  selector:
+    tool: Cerberus
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30000


### PR DESCRIPTION
This commit adds support to run containerized Cerberus as a Kubernetes/OpenShift deployment and thereby enabling the user to run Cerberus internally to the cluster.