### PR TITLE
Monitor apiserver availability 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Ingress                  | Watches Routers                                      
 Openshift SDN            | Watches SDN pods                                                                                   | :heavy_check_mark:        |
 OVNKubernetes            | Watches OVN pods                                                                                   | :heavy_check_mark:        |
 Cluster Operators        | Watches all Cluster Operators                                                                      | :heavy_check_mark:        |
-Master Nodes Schedule    | Watches schedule of Master Nodes                                                                     | :heavy_check_mark:        |
+Master Nodes Schedule    | Watches schedule of Master Nodes                                                                   | :heavy_check_mark:        |
+Api Server               | Watches the api server availability                                                                | :heavy_check_mark:        |
 
 NOTE: It supports monitoring pods in any namespaces specified in the config, the watch is enabled for system components mentioned above by default as they are critical for running the operations on Kubernetes/OpenShift clusters.
 

--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from kubernetes import client, config
 import cerberus.invoke.command as runcommand
 from kubernetes.client.rest import ApiException
-
+import requests
+from urllib3.exceptions import InsecureRequestWarning
 
 pods_tracker = defaultdict(dict)
 
@@ -190,3 +191,14 @@ def get_taint_from_describe(node_name):
     # Need to get the taint type and take out any extra spaces
     taint_info = node_taint.split(':')[-1].replace(" ", '')
     return taint_info
+
+
+# See if url is available
+def is_url_available(url):
+
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+    response = requests.get(url, verify=False)
+    if response.status_code != 200:
+        return False
+    else:
+        return True


### PR DESCRIPTION
https://github.com/openshift-scale/cerberus/issues/47

This issue will monitor the downtime of the api server. If the <api-server-url>/healthz does not receive a 200 status code, it will start a timer to see the amount of downtime until the url gets a 200 status code again. 

I was only able to see this fail if I set the config to 2 seconds sleep in between each iteration.  

Will work on fixing the conflicts and will need to squash commits. 
