### PR TITLE
Verify not scheduled status on master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set the supported components to monitor and the tunings like number of iteration
 cerberus:
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
-    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified
+    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified 
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
         -    openshift-apiserver
@@ -168,6 +168,7 @@ Ingress                  | Watches Routers                                      
 Openshift SDN            | Watches SDN pods                                                                                   | :heavy_check_mark:        |
 OVNKubernetes            | Watches OVN pods                                                                                   | :heavy_check_mark:        |
 Cluster Operators        | Watches all Cluster Operators                                                                      | :heavy_check_mark:        |
+Master Nodes Schedule    | Watches schedule of Master Nodes                                                                     | :heavy_check_mark:        |
 
 NOTE: It supports monitoring pods in any namespaces specified in the config, the watch is enabled for system components mentioned above by default as they are critical for running the operations on Kubernetes/OpenShift clusters.
 

--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -181,3 +181,12 @@ def monitor_cluster_operator(cluster_operators):
     else:
         status = True
     return status, failed_operators
+
+
+# This will get the taint information for each of the master nodes
+def get_taint_from_describe(node_name):
+    # Will return the taints for the master nodes
+    node_taint = runcommand.invoke("kubectl describe nodes/" + node_name + ' | grep Taints')
+    # Need to get the taint type and take out any extra spaces
+    taint_info = node_taint.split(':')[-1].replace(" ", '')
+    return taint_info


### PR DESCRIPTION
https://github.com/openshift-scale/cerberus/issues/42

Here I am getting the list of nodes every iteration and then finding only the master nodes and verifying that they have a NoSchedule taint status. Do I need to get the list of master nodes every iteration in case a new one gets created or one gets deleted? Or will the name/list of master nodes be consistent? 

Right now I did not add this check to the cerberus status. Do we want to add this? Or just log the scheduling status of the master nodes
