### PR TITLE
Enabled multiprocessing in Cerberus monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ tunings:
     sleep_time: 60                                       # Sleep duration between each iteration
     kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
+    cores_usage_percentage: 0.5                          # Set the fraction of cores to be used for multiprocessing
 
 database:
     database_path: /tmp/cerberus.db                      # Path where cerberus database needs to be stored

--- a/cerberus/inspect/inspect.py
+++ b/cerberus/inspect/inspect.py
@@ -11,12 +11,11 @@ def delete_inspect_directory():
         runcommand.invoke("rm -R inspect_data")
 
 
-def inspect_components(failed_pods_components):
-    for namespace in failed_pods_components.keys():
-        dir_name = "inspect_data/" + namespace + "-logs"
-        if os.path.isdir(dir_name):
-            runcommand.invoke("rm -R " + dir_name)
-            logging.info("Deleted existing %s directory" % (dir_name))
-        command_out = runcommand.invoke("oc adm inspect ns/" + namespace + " --dest"
-                                        "-dir=" + dir_name + " | tr -d '\n'")
-        logging.info(command_out)
+def inspect_component(namespace):
+    dir_name = "inspect_data/" + namespace + "-logs"
+    if os.path.isdir(dir_name):
+        runcommand.invoke("rm -R " + dir_name)
+        logging.info("Deleted existing %s directory" % (dir_name))
+    command_out = runcommand.invoke("oc adm inspect ns/" + namespace + " --dest"
+                                    "-dir=" + dir_name + " | tr -d '\n'")
+    logging.info(command_out)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,6 +41,7 @@ tunings:
     sleep_time: 60                                       # Sleep duration between each iteration
     kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
+    cores_usage_percentage: 0.5                          # Set the fraction of cores to be used for multiprocessing
 
 database:
     database_path: /tmp/cerberus.db                      # Path where cerberus database needs to be stored


### PR DESCRIPTION
This commit:
- Enables Cerberus to perform all checks enabled in the config
  parallelly using multiprocessing.
- Uses multiprocessing to monitor namespaces in watch_namespaces
  to check for failed components.
- Uses multiprocessing to collect detailed logs of failed namespaces.
- Uses multiprocessing to check for pod crash/restart in each
  namespaces during the sleep interval.

The detailed description of how multiprocessing helps in speeding the Cerberus monitoring and the results for the same can be found in this [doc](https://docs.google.com/document/d/112IgkFmViu4eusUL5-6BlKbpwHGmb1YErretKn0QQ1M/edit?usp=sharing).

Fixes #23 as well