### PR TITLE
Adding check for status and condition of cluster operators

### DIFF
--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -170,11 +170,15 @@ def monitor_cluster_operator(cluster_operators):
     failed_operators = []
     for operator in cluster_operators['items']:
         # loop through the conditions in the status section to find the dedgraded condition
-        for status_cond in operator['status']['conditions']:
-            # if the degraded status is not false, add it to the failed operators to return
-            if status_cond['type'] == "Degraded" and status_cond['status'] != "False":
-                failed_operators.append(operator['metadata']['name'])
-                break
+        if "status" in operator.keys() and "conditions" in operator['status'].keys():
+            for status_cond in operator['status']['conditions']:
+                # if the degraded status is not false, add it to the failed operators to return
+                if status_cond['type'] == "Degraded" and status_cond['status'] != "False":
+                    failed_operators.append(operator['metadata']['name'])
+                    break
+        else:
+            logging.info("Can't find status of " + operator['metadata']['name'])
+            failed_operators.append(operator['metadata']['name'])
     # if failed operators is not 0, return a failure
     # else return pass
     if len(failed_operators) != 0:


### PR DESCRIPTION
There are a couple of times I have found that when getting the cluster operators there is not a status or conditions section of the yaml. I am adding in an if/else statement for this instance and add the cluster operator to the list of failed operators if it does not have this section.

Without this code the cerberus run fails out 
