### PR TITLE
Added support to check for master NoSchedule taint

### DIFF
--- a/cerberus/server/server.py
+++ b/cerberus/server/server.py
@@ -21,7 +21,7 @@ def start_server(address):
     server = address[0]
     port = address[1]
     httpd = HTTPServer(address, SimpleHTTPRequestHandler)
-    logging.info("Starting http server at http://%s:%s" % (server, port))
+    logging.info("Starting http server at http://%s:%s\n" % (server, port))
     try:
         _thread.start_new_thread(httpd.serve_forever, ())
     except Exception:


### PR DESCRIPTION
This commit:
- Checks for NoSchedule taint on each master node and warns the
user if there are master nodes without NoSchedule taint.
- Performs the check once in every 10 iterations to reduce the
number of api calls.
- Uses more pythonic way to check for an empty list.

Fixes: #69 