### PR TITLE
Monitor routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ cerberus:
     distribution: openshift                              # Distribution can be kubernetes or openshift
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
-    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified 
+    watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified
+    watch_url_routes:                                    # Route url's you want to monitor
+        - - https://...
+          - Bearer ****                                  #This parameter is optional, specify authorization need for get call to route 
+        - - http://...
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
         -    openshift-apiserver
@@ -173,6 +177,7 @@ Nodes                    | Watches all the nodes including masters, workers as w
 Namespaces               | Watches all the pods including containers running inside the pods in the namespaces specified in the config | :heavy_check_mark:        |
 Cluster Operators        | Watches all Cluster Operators                                                                               | :heavy_check_mark:        |
 Master Nodes Schedule    | Watches schedule of Master Nodes                                                                            | :heavy_check_mark:        |
+Routes                   | Watches specified routes                                                                                    | :heavy_check_mark:        | 
 
 **NOTE**: It supports monitoring pods in any namespaces specified in the config, the watch is enabled for system components mentioned in the [config](https://github.com/openshift-scale/cerberus/blob/master/config/config.yaml) by default as they are critical for running the operations on Kubernetes/OpenShift clusters.
 

--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -1,13 +1,13 @@
-import yaml
 import logging
-import requests
 from collections import defaultdict
 from kubernetes import client, config
 import cerberus.invoke.command as runcommand
 from kubernetes.client.rest import ApiException
+import yaml
+import requests
 from urllib3.exceptions import InsecureRequestWarning
 
-
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 pods_tracker = defaultdict(dict)
 
 
@@ -205,9 +205,8 @@ def check_master_taint(master_nodes):
 
 
 # See if url is available
-def is_url_available(url):
-    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
-    response = requests.get(url, verify=False)
+def is_url_available(url, header=None):
+    response = requests.get(url, headers=header, verify=False)
     if response.status_code != 200:
         return False
     else:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,7 @@ cerberus:
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators
+    watch_url_routes:                                    # Route url's you want to monitor, this is a double array with the url and optional authorization parameter
     watch_namespaces:                                    # List of namespaces to be monitored
         -    openshift-etcd
         -    openshift-apiserver


### PR DESCRIPTION
https://github.com/openshift-scale/cerberus/issues/48

This pull request will allow us to monitor routes associated with the defined namespaces and other routes/urls that the user specifies.

Right now I have it set up that a user will need to log in so that the api calls can use a bearer token, using the body response of "oc whoami -t". I could instead add the bearer token as a variable in the config file, what are some thoughts on this? 

Are there any times that the bearer token might not be the correct authorization when doing a GET call on the routes? 