### PR TITLE
Added cerbeurs config file for Kubernetes distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ tunings:
 ```
 **NOTE**: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.
 
-**NOTE**: The components especially the namespaces needs to be changed depending on the distribution i.e Kubernetes or OpenShift. The default specified in the config assumes that the distribution is OpenShift.
+**NOTE**: The components especially the namespaces needs to be changed depending on the distribution i.e Kubernetes or OpenShift. The default specified in the config assumes that the distribution is OpenShift. A config file for Kubernetes is located at config/kubernetes_config.yaml
 
 #### Run
 ```

--- a/config/kubernetes_config.yaml
+++ b/config/kubernetes_config.yaml
@@ -1,0 +1,33 @@
+cerberus:
+    distribution: kubernetes                             # Distribution can be kubernetes or openshift
+    kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
+    watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
+    watch_cluster_operators: False                       # Set to True for cerberus to monitor cluster operators. Enable it only when distribution is openshift
+    watch_url_routes:                                    # Route url's you want to monitor, this is a double array with the url and optional authorization parameter
+    watch_namespaces:                                    # List of namespaces to be monitored
+        -    kube-system
+    cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
+    inspect_components: False                            # Enable it only when OpenShift client is supported to run
+                                                         # When enabled, cerberus collects logs, events and metrics of failed components
+
+    prometheus_url:                                      # The prometheus url/route is automatically obtained in case of OpenShift, please set it when the distribution is Kubernetes.
+    prometheus_bearer_token:                             # The bearer token is automatically obtained in case of OpenShift, please set it when the distribution is Kubernetes. This is needed to authenticate with prometheus.
+                                                         # This enables Cerberus to query prometheus and alert on observing high Kube API Server latencies.
+
+    slack_integration: False                             # When enabled, cerberus reports the failed iterations in the slack channel
+                                                         # The following env vars needs to be set: SLACK_API_TOKEN ( Bot User OAuth Access Token ) and SLACK_CHANNEL ( channel to send notifications in case of failures )
+                                                         # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in the slack channel. Values are slack member ID's.
+    cop_slack_ID:                                        # (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
+        Monday:
+        Tuesday:
+        Wednesday:
+        Thursday:
+        Friday:
+        Saturday:
+        Sunday:
+    slack_team_alias:                                    # The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned
+
+tunings:
+    iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
+    sleep_time: 60                                       # Sleep duration between each iteration
+    daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -56,10 +56,12 @@ def main(cfg):
 
         # Cluster info
         logging.info("Fetching cluster info")
-        cluster_version = runcommand.invoke("kubectl get clusterversion")
+        if distribution == "openshift":
+            cluster_version = runcommand.invoke("kubectl get clusterversion")
+            logging.info("\n%s" % (cluster_version))
         cluster_info = runcommand.invoke("kubectl cluster-info | awk 'NR==1' | sed -r "
                                          "'s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g'")  # noqa
-        logging.info("\n%s%s" % (cluster_version, cluster_info))
+        logging.info("%s" % (cluster_info))
 
         # Run http server using a separate thread if cerberus is asked
         # to publish the status. It is served by the http server.
@@ -96,7 +98,7 @@ def main(cfg):
         # enabled or else set it to the provided iterations count in the config
         if daemon_mode:
             logging.info("Daemon mode enabled, cerberus will monitor forever")
-            logging.info("Ignoring the iterations set")
+            logging.info("Ignoring the iterations set\n")
             iterations = float('inf')
         else:
             iterations = int(iterations)
@@ -146,7 +148,7 @@ def main(cfg):
                 watch_nodes_status = True
 
             # Monitor cluster operators status
-            if watch_cluster_operators:
+            if distribution == "openshift" and watch_cluster_operators:
                 watch_co_start_time = time.time()
                 status_yaml = kubecli.get_cluster_operators()
                 watch_cluster_operators_status, failed_operators = \
@@ -155,9 +157,6 @@ def main(cfg):
                 logging.info("Iteration %s: Cluster Operator status: %s"
                              % (iteration, watch_cluster_operators_status))
             else:
-                logging.info("Cerberus is not monitoring cluster operators, "
-                             "so setting the status to True and "
-                             "assuming that the cluster operators are ready")
                 watch_cluster_operators_status = True
 
             if iteration == 1:


### PR DESCRIPTION
The system related objects in Kubernetes are placed under
kube-system namespace; therefore by default only kube-system
is placed under watch_namespaces in config file for kubernetes.