### PR TITLE
Reduce the load on API server for bulk requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cerberus:
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
+    kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
 ```
 **NOTE**: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,4 +38,5 @@ cerberus:
 tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
+    kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -45,13 +45,14 @@ def main(cfg):
         prometheus_bearer_token = config["cerberus"].get("prometheus_bearer_token", "")
         iterations = config["tunings"].get("iterations", 0)
         sleep_time = config["tunings"].get("sleep_time", 0)
+        request_chunk_size = config["tunings"].get("kube_api_request_chunk_size", 250)
         daemon_mode = config["tunings"].get("daemon_mode", False)
 
-        # Initialize clients
+        # Initialize clients and set kube api request chunk size
         if not os.path.isfile(kubeconfig_path):
             kubeconfig_path = None
         logging.info("Initializing client to talk to the Kubernetes cluster")
-        kubecli.initialize_clients(kubeconfig_path)
+        kubecli.initialize_clients(kubeconfig_path, request_chunk_size)
 
         if "openshift-sdn" in watch_namespaces:
             sdn_namespace = kubecli.check_sdn_namespace()


### PR DESCRIPTION
This commit enables Cerberus to handle bulk requests in chunks
instead of a single go as it can generate a very large response
when there are thousands of objects running in the cluster and
overload the server by consuming a large amount of resources.
The chunk size is set to 250 by default to break the large request
while still preserving the consistency of the total request and
improve responsiveness.