### PR TITLE
Enabled operations time comparison in CI

### DIFF
--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -4,6 +4,7 @@ import os
 import sys
 import yaml
 import time
+import json
 import logging
 import optparse
 import pyfiglet
@@ -20,6 +21,22 @@ import cerberus.prometheus.client as promcli
 def publish_cerberus_status(status):
     with open('/tmp/cerberus_status', 'w+') as file:
         file.write(str(status))
+
+
+# Create a json file of operation timings
+def record_time(time_tracker):
+    if time_tracker:
+        average = defaultdict(float)
+        for check in time_tracker["Iteration 1"]:
+            iterations = 0
+            for values in time_tracker.values():
+                if check in values:
+                    average[check] += values[check]
+                    iterations += 1
+            average[check] /= iterations
+        time_tracker["Average"] = average
+    with open('./time_tracker.json', 'w+') as file:
+        json.dump(time_tracker, file, indent=4, separators=(',', ': '))
 
 
 # Main function
@@ -95,6 +112,10 @@ def main(cfg):
 
         # Counter for if api server is not ok
         api_fail_count = 0
+
+        # Track time taken for different checks in each iteration
+        global time_tracker
+        time_tracker = {}
 
         # Initialize the start iteration to 0
         iteration = 0
@@ -292,6 +313,8 @@ def main(cfg):
             # Capture total time taken by the iteration
             iter_track_time['entire_iteration'] = (time.time() - iteration_start_time) - sleep_time  # noqa
 
+            time_tracker["Iteration " + str(iteration)] = iter_track_time
+
             # Print the captured timing for each operation
             logging.info("-------------------------- Iteration Stats ---------------------------")
             for operation, timing in iter_track_time.items():
@@ -302,6 +325,7 @@ def main(cfg):
         else:
             logging.info("Completed watching for the specified number of iterations: %s"
                          % (iterations))
+            record_time(time_tracker)
     else:
         logging.error("Could not find a config at %s, please check" % (cfg))
         sys.exit(1)
@@ -332,4 +356,5 @@ if __name__ == "__main__":
         try:
             main(options.cfg)
         except KeyboardInterrupt:
+            record_time(time_tracker)
             logging.info("Terminating cerberus monitoring")

--- a/test.sh
+++ b/test.sh
@@ -62,6 +62,28 @@ do
   cat $test_dir/ci_results >> ci_results
 done
 
+if [[ -d "test_daemon_disabled" ]]; then
+  echo "" >> results.markdown
+  echo 'Check | Gold time (s) | PR time (s) | % Change' >> results.markdown
+  echo '------|---------------|-------------|---------' >> results.markdown
+  checks_in_pr=`jq '.Average | keys | .[]' test_daemon_disabled/time_tracker.json`
+  checks_in_master=`jq '.Average | keys | .[]' time_tracker.json`
+  for check in $checks_in_pr; do
+    pr_time=$(jq -r ".Average[$check]" test_daemon_disabled/time_tracker.json);
+    if [[ `echo $checks_in_master | grep -w $check` ]];
+    then
+      gold_time=$(jq -r ".Average[$check]" time_tracker.json);
+      delta=$(bc -l <<<"scale=2; (${pr_time}-${gold_time})/(${gold_time}*0.01)")
+      gold_time=$(bc -l <<<"scale=6; ${gold_time}/1")
+      pr_time=$(bc -l <<<"scale=6; ${pr_time}/1")
+      echo "$check | $gold_time | $pr_time | $delta" >> results.markdown
+    else
+      pr_time=$(bc -l <<<"scale=6; ${pr_time}/1")
+      echo "$check | | $pr_time | " >> results.markdown
+    fi
+  done
+fi
+
 # Get number of successes/failures
 testcount=`wc -l ci_results`
 success=`grep Successful ci_results | awk -F ":" '{print $1}'`


### PR DESCRIPTION
This commit enables the comparison of time taken for individual
checks/operations in PR against gold values in CI and displays the
percentage change.

Fixes: #81 