### PR TITLE
Throw an exception when invalid namespaces are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cerberus:
         -    openshift-apiserver
         -    openshift-kube-apiserver
         -    openshift-monitoring
-        -    openshift-kube-controller
+        -    openshift-kube-controller-manager
         -    openshift-machine-api
         -    openshift-kube-scheduler
         -    openshift-ingress

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ cerberus:
         -    openshift-apiserver
         -    openshift-kube-apiserver
         -    openshift-monitoring
-        -    openshift-kube-controller
+        -    openshift-kube-controller-manager
         -    openshift-machine-api
         -    openshift-kube-scheduler
         -    openshift-ingress

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -54,6 +54,9 @@ def main(cfg):
         logging.info("Initializing client to talk to the Kubernetes cluster")
         kubecli.initialize_clients(kubeconfig_path, request_chunk_size)
 
+        # Check if all the namespaces under watch_namespaces are valid
+        kubecli.check_namespaces(watch_namespaces)
+
         if "openshift-sdn" in watch_namespaces:
             sdn_namespace = kubecli.check_sdn_namespace()
             watch_namespaces = [namespace.replace('openshift-sdn', sdn_namespace)


### PR DESCRIPTION
This commit:
- Throws an exception displaying invalid namespaces and terminates
  cerberus monitoring.
- Reorders functions in cerberus/kubernetes/client.py to place similar
  functions together.
- Replaces "openshift-kube-controller" with "openshift-kube-controller-manager"
  as "openshift-kube-controller" isn't a valid namespace in OpenShift
  by default.

Fixes: #44 