### PR TITLE
watch_namespaces supports regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ tunings:
     kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
 ```
+**NOTE**: watch_namespaces support regex patterns. Any valid regex pattern can be used to watch all the namespaces matching the regex pattern. For example, `^openshift-.*$` can be used to watch all namespaces that start with `openshift-` or `openshift` can be used to watch all namespaces that have `openshift` in it.
+
 **NOTE**: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.
 
 **NOTE**: The components especially the namespaces needs to be changed depending on the distribution i.e Kubernetes or OpenShift. The default specified in the config assumes that the distribution is OpenShift. A config file for Kubernetes is located at config/kubernetes_config.yaml

--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import yaml
 import json
@@ -96,11 +97,23 @@ def get_all_pod_info(namespace):
 
 
 # Check if all the watch_namespaces are valid
-def check_namespaces(watch_namespaces):
+def check_namespaces(namespaces):
     try:
-        invalid_namespaces = set(watch_namespaces) - set(list_namespaces())
+        valid_namespaces = list_namespaces()
+        regex_namespaces = set(namespaces) - set(valid_namespaces)
+        final_namespaces = set(namespaces) - set(regex_namespaces)
+        valid_regex = set()
+        if regex_namespaces:
+            for namespace in valid_namespaces:
+                for regex_namespace in regex_namespaces:
+                    if re.search(regex_namespace, namespace):
+                        final_namespaces.add(namespace)
+                        valid_regex.add(regex_namespace)
+                        break
+        invalid_namespaces = regex_namespaces - valid_regex
         if invalid_namespaces:
-            raise Exception("Following namespaces do not exist: %s" % (invalid_namespaces))
+            raise Exception("There exists no namespaces matching: %s" % (invalid_namespaces))
+        return list(final_namespaces)
     except Exception as e:
         logging.info("%s" % (e))
         sys.exit(1)

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -72,7 +72,7 @@ def main(cfg):
         kubecli.initialize_clients(kubeconfig_path, request_chunk_size)
 
         # Check if all the namespaces under watch_namespaces are valid
-        kubecli.check_namespaces(watch_namespaces)
+        watch_namespaces = kubecli.check_namespaces(watch_namespaces)
 
         if "openshift-sdn" in watch_namespaces:
             sdn_namespace = kubecli.check_sdn_namespace()


### PR DESCRIPTION
This commit supports regex patterns to be used in watch_namespaces.
For example, `^openshift-.*$` can be used to watch all namespaces
that start with `openshift-` or `.*openshift.*` can be used to watch
all namespaces that have `openshift` in it. Providing `openshift` would
match only openshift namespace.

Fixes: #86 