### PR TITLE
Supports http server port parameterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Set the supported components to monitor and the tunings like number of iteration
 cerberus:
     distribution: openshift                              # Distribution can be kubernetes or openshift
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
+    port: 8080                                           # http server port where cerberus status is published
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators. Parameter is optional, will set to True if not specified
     watch_url_routes:                                    # Route url's you want to monitor

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,7 @@
 cerberus:
     distribution: openshift                              # Distribution can be kubernetes or openshift
     kubeconfig_path: ~/.kube/config                      # Path to kubeconfig
+    port: 8080                                           # http server port where cerberus status is published
     watch_nodes: True                                    # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: True                        # Set to True for cerberus to monitor cluster operators
     watch_url_routes:                                    # Route url's you want to monitor, this is a double array with the url and optional authorization parameter

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -51,6 +51,7 @@ def main(cfg):
             config = yaml.full_load(f)
         distribution = config["cerberus"].get("distribution", "openshift").lower()
         kubeconfig_path = config["cerberus"].get("kubeconfig_path", "")
+        port = config["cerberus"].get("port", 8080)
         watch_nodes = config["cerberus"].get("watch_nodes", False)
         watch_cluster_operators = config["cerberus"].get("watch_cluster_operators", False)
         watch_namespaces = config["cerberus"].get("watch_namespaces", [])
@@ -91,7 +92,10 @@ def main(cfg):
         # Run http server using a separate thread if cerberus is asked
         # to publish the status. It is served by the http server.
         if cerberus_publish_status:
-            address = ("0.0.0.0", 8080)
+            if not 0 <= port <= 65535:
+                logging.info("Using port 8080 as %s isn't a valid port number" % (port))
+                port = 8080
+            address = ("0.0.0.0", port)
             server_address = address[0]
             port = address[1]
             logging.info("Publishing cerberus status at http://%s:%s"


### PR DESCRIPTION
This commits supports parameterization of the http server port to enable the server run on different ports.

Fixes: #2  