### PR TITLE
add timestamp to slack messages

### DIFF
--- a/cerberus/slack/slack_client.py
+++ b/cerberus/slack/slack_client.py
@@ -1,6 +1,7 @@
 import os
 import slack
 import logging
+import datetime
 import cerberus.invoke.command as runcommand
 
 
@@ -69,8 +70,10 @@ def slack_logging(cluster_info, iteration, watch_nodes_status, failed_nodes,
     if not watch_namespaces_status:
         issues.append("*namespaces: " + ", ".join(list(failed_pods_components.keys())) + "*")
     issues = "\n".join(issues)
-    post_message_in_slack(slack_tag + " %sIn iteration %d, Cerberus "
+    post_message_in_slack(slack_tag + " %sIn iteration %d at %s, Cerberus "
                           "found issues in: \n%s \nHence, setting the "
                           "go/no-go signal to false. \nThe full report "
                           "is at *%s* on the host cerberus is running."
-                          % (cluster_info, iteration, issues, cerberus_report_path))
+                          % (cluster_info, iteration,
+                              datetime.datetime.now().replace(microsecond=0).isoformat(),
+                              issues, cerberus_report_path))


### PR DESCRIPTION
for better readability in slack

```
Kubernetes master is running at https://api.msheth.perfscale.gcp.devcluster.openshift.com:6443
In iteration 3 at 2020-07-09T20:44:29, Cerberus found issues in:    
namespaces: openshift-ingress     
Hence, setting the go/no-go signal to false.     
The full report is at /tmp/cerberus on the host cerberus is running.   
```
