### PR TITLE
Alert on high number of leader changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = {posargs}
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.
 show-source = True
-max-line-length = 100
+max-line-length = 110
 ignore = E123,E125
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
This commit :
- Enables cerberus to alerts the user when an increase in etcd leader
  changes are observed on the cluster. Frequent elections may be a sign
  of insufficient resources, high network latency, or disruptions by
  other components and should be investigated. This is just a warning
  and is not taken into consideration for determining the go/no-go signal.
- Updates the linter to allow 110 chars per line.