### PR TITLE
Bake in additional dependencies

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=origintests /usr/bin/oc /usr/bin/oc
 COPY --from=origintests /usr/bin/kubectl /usr/bin/kubectl
 
 # Install dependencies
-RUN yum install -y git python36 python3-pip && \
+RUN yum install -y git python36 python3-pip gcc python3-devel && \
 git clone https://github.com/openshift-scale/cerberus /root/cerberus && \
 mkdir -p /root/.kube && cd /root/cerberus && \
 pip3 install -r requirements.txt


### PR DESCRIPTION
The container needs gcc and python3-devel as the dependencies for
the image build process to succeed.